### PR TITLE
Block all the verge scripts, remove footer filter

### DIFF
--- a/custom-filters.txt
+++ b/custom-filters.txt
@@ -113,5 +113,5 @@ folha.uol.com.br##.c-estudio-folha
 www1.folha.uol.com.br##.aside-menu > .nav
 ! 24/01/2025 https://www.duolingo.com
 duolingo.com##div._3D_HB
-! 24/01/2025 https://www.theverge.com
-theverge.com##.zephr-zone-footer
+! 2025-03-01 https://www.theverge.com
+theverge.com##^script


### PR DESCRIPTION
* Remove ineffective footer blocker for theverge
* Nuclear option: Block all scripts on theverge. Reduced functionality but no nonsense client side paywall.