### PR TITLE
Disable sticky recommendations on autosport

### DIFF
--- a/custom-filters.txt
+++ b/custom-filters.txt
@@ -117,3 +117,5 @@ duolingo.com##div._3D_HB
 arstechnica.com##.ars-interlude-container
 ! 14 Aug 2025
 ||assets.zephr.com/zephr-browser/*/zephr-browser.umd.js
+! 3 Sep 2025
+autosport.com##.msnt-sticky-recommendations-strip


### PR DESCRIPTION
Autosport has an annoying sticky banner with recommendations very poorly implemented, that's always covering the content.